### PR TITLE
Fix react-docgen optional chaining

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2337,11 +2337,6 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
-    "ast-types": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
-      "integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA=="
-    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -9604,6 +9599,14 @@
             "to-fast-properties": "^2.0.0"
           }
         },
+        "ast-types": {
+          "version": "0.14.2",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+          "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+          "requires": {
+            "tslib": "^2.0.1"
+          }
+        },
         "convert-source-map": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -9621,6 +9624,11 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+        },
+        "tslib": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zeplin/cli-connect-react-plugin",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zeplin/cli-connect-react-plugin",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Zeplin CLI Connected Components - React Plugin",
   "main": "./dist/index",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "jest",
     "build": "tsc && copyfiles -u 1 src/template/** dist/",
     "lint": "eslint --ext .js,.ts .",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "preinstall": "npx npm-force-resolutions"
   },
   "husky": {
     "hooks": {
@@ -45,5 +46,8 @@
     "fs-extra": "^9.0.0",
     "pug": "^2.0.4",
     "react-docgen": "^5.3.0"
+  },
+  "resolutions": {
+    "ast-types": "^0.14.0"
   }
 }


### PR DESCRIPTION
Hotfix to enforce resolution of `ast-types`.

Fixes #24 