### PR TITLE
Add multi export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [Zeplin CLI](https://github.com/zeplin/cli) plugin to generate descriptions and code snippets for React components.
 
+Zeplin CLI React Plugin uses [react-docgen](https://github.com/reactjs/react-docgen) and [react-docgen-typescript](https://github.com/styleguidist/react-docgen-typescript) to analyze and collect information from React components. For more details about the supported formats, see `react-docgen` [guidelines](https://github.com/reactjs/react-docgen#guidelines-for-default-resolvers-and-handlers) and `react-docgen-typescript` [examples](https://github.com/styleguidist/react-docgen-typescript#example).
+
 ## Installation
 
 Install the plugin using npm.
@@ -18,7 +20,7 @@ Run CLI `connect` command using the plugin.
 zeplin connect -p @zeplin/cli-connect-react-plugin
 ```
 
-Zeplin CLI React Plugin uses [react-docgen](https://github.com/reactjs/react-docgen) and [react-docgen-typescript](https://github.com/styleguidist/react-docgen-typescript) to analyze and collect information from React components. For more details about the supported formats, see `react-docgen` [guidelines](https://github.com/reactjs/react-docgen#guidelines-for-default-resolvers-and-handlers) and `react-docgen-typescript` [examples](https://github.com/styleguidist/react-docgen-typescript#example).
+### Using react-docgen-typescript for Typescript components
 
 You can choose to use either `react-docgen` or `react-docgen-typescript` for TypeScript in your plugin configurations.
 
@@ -28,8 +30,26 @@ You can choose to use either `react-docgen` or `react-docgen-typescript` for Typ
     "plugins" : [{
         "name": "@zeplin/cli-connect-react-plugin",
         "config": {
-            "tsDocgen": "react-docgen-typescript", // Uses react-docgen by default
-            "tsConfigPath": "/path/to/tsconfig.json" // Defaults to ./tsconfig.json
+            "tsDocgen": "react-docgen-typescript", // Default: "react-docgen"
+            "tsConfigPath": "/path/to/tsconfig.json" // Default: "./tsconfig.json"
+        }
+    }],
+    ...
+}
+```
+
+### Using react-docgen resolvers
+
+You can set which built-in `react-docgen` resolver to use.
+
+```jsonc
+{
+    ...
+    "plugins" : [{
+        "name": "@zeplin/cli-connect-react-plugin",
+        "config": {
+            // Default: "findAllExportedComponentDefinitions"
+            "reactDocgenResolver": "findExportedComponentDefinition",
         }
     }],
     ...
@@ -39,5 +59,7 @@ You can choose to use either `react-docgen` or `react-docgen-typescript` for Typ
 ## About Connected Components
 
 [Connected Components](https://blog.zeplin.io/introducing-connected-components-components-in-design-and-code-in-harmony-aa894ed5bd95) in Zeplin lets you access components in your codebase directly on designs in Zeplin, with links to Storybook, GitHub and any other source of documentation based on your workflow. 🧩
+
+Check [Zeplin Connected Components Documentation](https://zpl.io/connected-components-docs) for getting started.
 
 [Zeplin CLI](https://github.com/zeplin/cli) uses plugins like this one to analyze component source code and publishes a high-level overview to be displayed in Zeplin.

--- a/src/types/react-docgen.ts
+++ b/src/types/react-docgen.ts
@@ -118,7 +118,7 @@ declare module "react-docgen" {
 
   // Just minimal type definition of the method to use it
   export function parse(src: string | Buffer,
-    resolver?: null,
+    resolver?: string | unknown,
     handlers?: null,
-    options?: { filename: string; babelrc: boolean }): ComponentDoc;
+    options?: { filename: string; babelrc: boolean }): ComponentDoc | ComponentDoc[];
 }

--- a/test/__snapshots__/flow.test.ts.snap
+++ b/test/__snapshots__/flow.test.ts.snap
@@ -47,3 +47,22 @@ Object {
   obj={{ subvalue: boolean }} />",
 }
 `;
+
+exports[`Connected Components React Plugin - Flow MultiExportFlowComponentWithProps.jsx snippet creation 1`] = `
+Object {
+  "description": "Component 1 description. Only this one should be shown",
+  "lang": "jsx",
+  "snippet": "<MyComponent
+  primitive={number}
+  literalsAndUnion={'string' | 'otherstring' | number}
+  arr={Array<any>}
+  func={(value: string) => void}
+  noParameterName={string => void}
+  obj={{ subvalue: boolean }} />
+
+<MyOtherComponent
+  primitive={number}
+  literalsAndUnion={'string' | 'otherstring' | number}
+  arr={Array<any>} />",
+}
+`;

--- a/test/__snapshots__/functional.test.ts.snap
+++ b/test/__snapshots__/functional.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Connected Components React Plugin - Functional ComponentWithChildren.jsx snippet creation 1`] = `
+exports[`Connected Components React Plugin - Functional FunctionalComponentWithChildren.jsx snippet creation 1`] = `
 Object {
   "description": "",
   "lang": "jsx",
@@ -15,5 +15,20 @@ Object {
   "description": "",
   "lang": "jsx",
   "snippet": "<MyComponent />",
+}
+`;
+
+exports[`Connected Components React Plugin - Functional MultiExportFunctionalComponentWithChildren.jsx snippet creation 1`] = `
+Object {
+  "description": "Component 1 description. Only this one should be shown",
+  "lang": "jsx",
+  "snippet": "<MyComponent1>
+  {children}
+</MyComponent1>
+
+<MyComponent2
+  someParameter={PropTypes.string.isRequired}>
+  {children}
+</MyComponent2>",
 }
 `;

--- a/test/__snapshots__/propType.test.ts.snap
+++ b/test/__snapshots__/propType.test.ts.snap
@@ -50,6 +50,38 @@ Object {
 }
 `;
 
+exports[`Connected Components React Plugin - PropTypes ComponentWithChildrenAndProps.jsx snippet creation with single export resolver 1`] = `
+Object {
+  "description": "Component description.",
+  "lang": "jsx",
+  "snippet": "<MyComponent
+  optionalArray={array}
+  optionalBool={bool}
+  optionalFunc={func}
+  optionalNumber={number}
+  optionalObject={object}
+  optionalString={string}
+  optionalSymbol={symbol}
+  optionalNode={node}
+  optionalElement={element}
+  optionalElementType={elementType}
+  optionalFoo={instanceOf(Foo)}
+  optionalEnum={enum}
+  optionalUnion={union[string|number|instanceOf(Foo)]}
+  optionalArrayOf={arrayOf[number]}
+  optionalObjectOf={objectOf[number]}
+  optionalObjectWithShape={shape}
+  optionalObjectWithStrictShape={exact}
+  requiredFunc={func}
+  requiredAny={any}
+  customProp={() => {}}
+  customArrayProp={arrayOf[custom]}
+  customObjectOfProp={objectOf[custom]}>
+  {children}
+</MyComponent>",
+}
+`;
+
 exports[`Connected Components React Plugin - PropTypes ComponentWithMemoization.jsx snippet creation 1`] = `
 Object {
   "description": "Component description.",
@@ -109,5 +141,44 @@ Object {
   customProp={() => {}}
   customArrayProp={arrayOf[custom]}
   customObjectOfProp={objectOf[custom]} />",
+}
+`;
+
+exports[`Connected Components React Plugin - PropTypes MultiExportComponentWithProps.jsx snippet creation 1`] = `
+Object {
+  "description": "Component 1 description. Only this one should be shown",
+  "lang": "jsx",
+  "snippet": "<MyComponent1
+  optionalArray={array}
+  optionalBool={bool}
+  optionalFunc={func}
+  optionalNumber={number}
+  optionalObject={object}
+  optionalString={string}
+  optionalSymbol={symbol}
+  optionalNode={node}
+  optionalElement={element}
+  optionalElementType={elementType}
+  optionalFoo={instanceOf(Foo)}
+  optionalEnum={enum}
+  optionalUnion={union[string|number|instanceOf(Foo)]}
+  optionalArrayOf={arrayOf[number]}
+  optionalObjectOf={objectOf[number]}
+  optionalObjectWithShape={shape}
+  optionalObjectWithStrictShape={exact}
+  requiredFunc={func}
+  requiredAny={any}
+  customProp={() => {}}
+  customArrayProp={arrayOf[custom]}
+  customObjectOfProp={objectOf[custom]} />
+
+<MyComponent2
+  optionalArray={array}
+  optionalBool={bool}
+  optionalFunc={func}
+  optionalNumber={number}
+  optionalObject={object}
+  optionalString={string}
+  optionalSymbol={symbol} />",
 }
 `;

--- a/test/__snapshots__/typescript.test.ts.snap
+++ b/test/__snapshots__/typescript.test.ts.snap
@@ -85,6 +85,36 @@ Object {
 }
 `;
 
+exports[`Connected Components React Plugin - TypeScript Using react-docgen-typescript MultiExportTSComponentWithProps.tsx snippet creation 1`] = `
+Object {
+  "description": "General component description.",
+  "lang": "tsx",
+  "snippet": "<MyComponent
+  message={string}
+  count={number}
+  disabled={boolean}
+  names={string[]}
+  status={'waiting' | 'success'}
+  obj={object}
+  obj2={{}}
+  obj3={{ id: string; title: string; }}
+  objArr={{ id: string; title: string; }[]}
+  onSomething={Function}
+  onClick={(event: MouseEvent<HTMLButtonElement, MouseEvent>) => void}
+  onChange={(id: number) => void}
+  optional={OptionalType} />
+
+<MyOtherComponent
+  message={string}
+  count={number}
+  disabled={boolean}
+  names={string[]}
+  status={'waiting' | 'success'}
+  obj={object}
+  obj2={{}} />",
+}
+`;
+
 exports[`Connected Components React Plugin - TypeScript Using react-docgen-typescript TSComponent.tsx snippet creation 1`] = `
 Object {
   "description": "General component description.",

--- a/test/flow.test.ts
+++ b/test/flow.test.ts
@@ -52,4 +52,17 @@ describe("Connected Components React Plugin - Flow", () => {
 
         expect(componentCode).toMatchSnapshot();
     });
+
+    test("MultiExportFlowComponentWithProps.jsx snippet creation", async () => {
+        const processor = new Plugin();
+
+        const componentCode = await processor.process(
+            {
+                path: "test/samples/flow/MultiExportFlowComponentWithProps.jsx",
+                zeplinNames: []
+            }
+        );
+
+        expect(componentCode).toMatchSnapshot();
+    });
 });

--- a/test/functional.test.ts
+++ b/test/functional.test.ts
@@ -14,12 +14,25 @@ describe("Connected Components React Plugin - Functional", () => {
         expect(componentCode).toMatchSnapshot();
     });
 
-    test("ComponentWithChildren.jsx snippet creation", async () => {
+    test("FunctionalComponentWithChildren.jsx snippet creation", async () => {
         const processor = new Plugin();
 
         const componentCode = await processor.process(
             {
                 path: "test/samples/jsx-functional/FunctionalComponentWithChildren.jsx",
+                zeplinNames: []
+            }
+        );
+
+        expect(componentCode).toMatchSnapshot();
+    });
+
+    test("MultiExportFunctionalComponentWithChildren.jsx snippet creation", async () => {
+        const processor = new Plugin();
+
+        const componentCode = await processor.process(
+            {
+                path: "test/samples/jsx-functional/MultiExportFunctionalComponentWithChildren.jsx",
                 zeplinNames: []
             }
         );

--- a/test/helper/logger.ts
+++ b/test/helper/logger.ts
@@ -1,0 +1,8 @@
+import { Logger } from "@zeplin/cli";
+
+export const logger: Logger = {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn()
+};

--- a/test/propType.test.ts
+++ b/test/propType.test.ts
@@ -1,5 +1,5 @@
 import Plugin from "../src";
-import { Logger } from "@zeplin/cli";
+import { logger } from "./helper/logger";
 
 describe("Connected Components React Plugin - PropTypes", () => {
     test("Component.jsx snippet creation", async () => {
@@ -84,7 +84,7 @@ describe("Connected Components React Plugin - PropTypes", () => {
         const processor = new Plugin();
         await processor.init({
             components: [],
-            logger: null as unknown as Logger,
+            logger,
             config: {
                 reactDocgenResolver: "findExportedComponentDefinition"
             }

--- a/test/propType.test.ts
+++ b/test/propType.test.ts
@@ -1,4 +1,5 @@
 import Plugin from "../src";
+import { Logger } from "@zeplin/cli";
 
 describe("Connected Components React Plugin - PropTypes", () => {
     test("Component.jsx snippet creation", async () => {
@@ -59,6 +60,39 @@ describe("Connected Components React Plugin - PropTypes", () => {
         const componentCode = await processor.process(
             {
                 path: "test/samples/jsx-class/ComponentWithMemoization.jsx",
+                zeplinNames: []
+            }
+        );
+
+        expect(componentCode).toMatchSnapshot();
+    });
+
+    test("MultiExportComponentWithProps.jsx snippet creation", async () => {
+        const processor = new Plugin();
+
+        const componentCode = await processor.process(
+            {
+                path: "test/samples/jsx-class/MultiExportComponentWithProps.jsx",
+                zeplinNames: []
+            }
+        );
+
+        expect(componentCode).toMatchSnapshot();
+    });
+
+    test("ComponentWithChildrenAndProps.jsx snippet creation with single export resolver", async () => {
+        const processor = new Plugin();
+        await processor.init({
+            components: [],
+            logger: null as unknown as Logger,
+            config: {
+                reactDocgenResolver: "findExportedComponentDefinition"
+            }
+        });
+
+        const componentCode = await processor.process(
+            {
+                path: "test/samples/jsx-class/ComponentWithChildrenAndProps.jsx",
                 zeplinNames: []
             }
         );

--- a/test/samples/flow/MultiExportFlowComponentWithProps.jsx
+++ b/test/samples/flow/MultiExportFlowComponentWithProps.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+type Props1 = {
+  primitive: number,
+  literalsAndUnion: 'string' | 'otherstring' | number,
+  arr: Array<any>,
+  func?: (value: string) => void,
+  noParameterName?: string => void,
+  obj?: { subvalue: boolean }
+};
+
+type Props2 = {
+  primitive: number,
+  literalsAndUnion: 'string' | 'otherstring' | number,
+  arr: Array<any>
+};
+
+/** Component 1 description. Only this one should be shown */
+export class MyComponent extends React.Component<void, Props1, void> {
+  props: Props1;
+
+  render(): ReactElement {
+    // ...
+  }
+}
+
+/** Component 2 description. This one should not be shown */
+export class MyOtherComponent extends React.Component<void, Props2, void> {
+  props: Props2;
+
+  render(): ReactElement {
+    // ...
+  }
+}

--- a/test/samples/jsx-class/MultiExportComponentWithProps.jsx
+++ b/test/samples/jsx-class/MultiExportComponentWithProps.jsx
@@ -1,0 +1,66 @@
+import PropTypes from "prop-types";
+
+class Foo {}
+
+/** Component 1 description. Only this one should be shown */
+class MyComponent1 extends React.Component {
+    render() {
+        return "";
+    }
+}
+
+/** Component 2 description. This one should not be shown */
+class MyComponent2 extends React.Component {
+    render() {
+        return "";
+    }
+}
+
+MyComponent1.propTypes = {
+    optionalArray: PropTypes.array,
+    optionalBool: PropTypes.bool,
+    optionalFunc: PropTypes.func,
+    optionalNumber: PropTypes.number,
+    optionalObject: PropTypes.object,
+    optionalString: PropTypes.string,
+    optionalSymbol: PropTypes.symbol,
+    optionalNode: PropTypes.node,
+    optionalElement: PropTypes.element,
+    optionalElementType: PropTypes.elementType,
+    optionalFoo: PropTypes.instanceOf(Foo),
+    optionalEnum: PropTypes.oneOf(["News", "Photos"]),
+    optionalUnion: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+        PropTypes.instanceOf(Foo)
+    ]),
+    optionalArrayOf: PropTypes.arrayOf(PropTypes.number),
+    optionalObjectOf: PropTypes.objectOf(PropTypes.number),
+    optionalObjectWithShape: PropTypes.shape({
+        color: PropTypes.string,
+        fontSize: PropTypes.number
+    }),
+    optionalObjectWithStrictShape: PropTypes.exact({
+        name: PropTypes.string,
+        quantity: PropTypes.number
+    }),
+    requiredFunc: PropTypes.func.isRequired,
+    requiredAny: PropTypes.any.isRequired,
+    customProp: () => {},
+    customArrayProp: PropTypes.arrayOf(() => {}),
+    customObjectOfProp: PropTypes.objectOf(() => {})
+};
+
+MyComponent2.propTypes = {
+    optionalArray: PropTypes.array,
+    optionalBool: PropTypes.bool,
+    optionalFunc: PropTypes.func,
+    optionalNumber: PropTypes.number,
+    optionalObject: PropTypes.object,
+    optionalString: PropTypes.string,
+    optionalSymbol: PropTypes.symbol
+}
+
+export const MyComponent = MyComponent1;
+
+export const MyOtherComponent = MyComponent2;

--- a/test/samples/jsx-functional/MultiExportFunctionalComponentWithChildren.jsx
+++ b/test/samples/jsx-functional/MultiExportFunctionalComponentWithChildren.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+/** Component 1 description. Only this one should be shown */
+const MyComponent1 = () => {
+  const thing = {
+    stuff: 'stuff',
+  };
+
+  const string = thing?.stuff;
+
+  return (
+    <div>
+      {string}
+    </div>
+  );
+};
+
+MyComponent1.propTypes = {
+  children: PropTypes.element.isRequired
+};
+
+/** Component 2 description. This one should not be shown */
+const MyComponent2 = () => {
+  const thing = {
+    stuff: 'stuff',
+  };
+
+  const string = thing?.stuff;
+
+  return (
+    <div>
+      {string}
+    </div>
+  );
+};
+
+MyComponent2.propTypes = {
+  children: PropTypes.element.isRequired,
+  someParameter: PropTypes.string.isRequired
+};
+
+export const MyComponent = MyComponent1;
+export const MyOtherComponent = MyComponent2;

--- a/test/samples/typescript/MultiExportTSComponentWithProps.tsx
+++ b/test/samples/typescript/MultiExportTSComponentWithProps.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+interface OptionalType {};
+
+type Props1 = {
+  message: string;
+  count: number;
+  disabled: boolean;
+  names: string[];
+  status: "waiting" | "success";
+  obj: object;
+  obj2: {};
+  obj3: {
+    id: string;
+    title: string;
+  };
+  objArr: {
+    id: string;
+    title: string;
+  }[];
+  onSomething: Function;
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onChange: (id: number) => void;
+  optional?: OptionalType;
+};
+
+type Props2 = {
+  message: string;
+  count: number;
+  disabled: boolean;
+  names: string[];
+  status: "waiting" | "success";
+  obj: object;
+  obj2: {};
+};
+
+/**
+ * General component description.
+ */
+export class MyComponent extends React.Component<Props1, {}> {
+  props: Props1;
+
+  render() {
+    // ...
+    return;
+  }
+}
+
+/**
+ * General component description.
+ */
+export class MyOtherComponent extends React.Component<Props2, {}> {
+  props: Props2;
+
+  render() {
+    // ...
+    return;
+  }
+}

--- a/test/samples/typescript/MultiExportTSComponentWithProps.tsx
+++ b/test/samples/typescript/MultiExportTSComponentWithProps.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 interface OptionalType {};
 
@@ -40,7 +40,7 @@ type Props2 = {
 export class MyComponent extends React.Component<Props1, {}> {
   props: Props1;
 
-  render() {
+  render(): ReactNode {
     // ...
     return;
   }
@@ -52,7 +52,7 @@ export class MyComponent extends React.Component<Props1, {}> {
 export class MyOtherComponent extends React.Component<Props2, {}> {
   props: Props2;
 
-  render() {
+  render(): ReactNode {
     // ...
     return;
   }

--- a/test/typescript.test.ts
+++ b/test/typescript.test.ts
@@ -1,4 +1,14 @@
 import Plugin from "../src";
+import { Logger } from "@zeplin/cli";
+
+const pluginContext = {
+    components: [],
+    logger: null as unknown as Logger,
+    config: {
+        tsDocgen: "react-docgen-typescript",
+        tsConfigPath: "./test/tsconfig.test.json"
+    }
+};
 
 describe("Connected Components React Plugin - TypeScript", () => {
     describe("Using react-docgen", () => {
@@ -72,6 +82,8 @@ describe("Connected Components React Plugin - TypeScript", () => {
         test("TSComponent.tsx snippet creation", async () => {
             const processor = new Plugin();
 
+            await processor.init(pluginContext);
+
             processor.config = {
                 tsDocgen: "react-docgen-typescript",
                 tsConfigPath: "./test/tsconfig.test.json"
@@ -90,10 +102,7 @@ describe("Connected Components React Plugin - TypeScript", () => {
         test("TSComponentWithProps.tsx snippet creation", async () => {
             const processor = new Plugin();
 
-            processor.config = {
-                tsDocgen: "react-docgen-typescript",
-                tsConfigPath: "./test/tsconfig.test.json"
-            };
+            await processor.init(pluginContext);
 
             const componentCode = await processor.process(
                 {
@@ -108,10 +117,7 @@ describe("Connected Components React Plugin - TypeScript", () => {
         test("TSComponentWithChildren.tsx snippet creation", async () => {
             const processor = new Plugin();
 
-            processor.config = {
-                tsDocgen: "react-docgen-typescript",
-                tsConfigPath: "./test/tsconfig.test.json"
-            };
+            await processor.init(pluginContext);
 
             const componentCode = await processor.process(
                 {
@@ -144,14 +150,26 @@ describe("Connected Components React Plugin - TypeScript", () => {
         test("TSComponentWithImport.tsx snippet creation", async () => {
             const processor = new Plugin();
 
-            processor.config = {
-                tsDocgen: "react-docgen-typescript",
-                tsConfigPath: "./test/tsconfig.test.json"
-            };
+            await processor.init(pluginContext);
 
             const componentCode = await processor.process(
                 {
                     path: "test/samples/typescript/TSComponentWithImport.tsx",
+                    zeplinNames: []
+                }
+            );
+
+            expect(componentCode).toMatchSnapshot();
+        });
+
+        test("MultiExportTSComponentWithProps.tsx snippet creation", async () => {
+            const processor = new Plugin();
+
+            await processor.init(pluginContext);
+
+            const componentCode = await processor.process(
+                {
+                    path: "test/samples/typescript/MultiExportTSComponentWithProps.tsx",
                     zeplinNames: []
                 }
             );

--- a/test/typescript.test.ts
+++ b/test/typescript.test.ts
@@ -1,9 +1,9 @@
 import Plugin from "../src";
-import { Logger } from "@zeplin/cli";
+import { logger } from "./helper/logger";
 
 const pluginContext = {
     components: [],
-    logger: null as unknown as Logger,
+    logger,
     config: {
         tsDocgen: "react-docgen-typescript",
         tsConfigPath: "./test/tsconfig.test.json"


### PR DESCRIPTION
This PR change default `react-docgen` resolver to `findAllExportedComponentDefinitions` which will collect all exported components on a file. Multiple snippets are generated using multi component definitions either on `react-docgen` and `react-docgen-typescript` and joined into one with line breaks, similar to what we did on Angular plugin. 

Current Zeplin UI does not have a practical way to show multiple component descriptions, hence only the first export description will be collected for now.

Users will be able to set `reactDocgenResolver` on the configuration file to change the default resolver.

Fixes: #15 

**Example:**
```ts
/**
 * Component description 1
 */
export const Button: React.FunctionComponent<Props> = (props: Props) => {
    const { type, children, className, onClick, onSubmit, ...rest } = props;
    const classes: string[] = className ? className.split(' ') : [''];
    const classNames: string = ['c-btn'].concat(classes).join(' ');

    return (
        <button className={classNames} type={type} onClick={onClick} {...rest}>
            {children}
        </button>
    );
};

/**
 * Component Description 2
 */
export const Button2: React.FunctionComponent<Props> = (props: Props) => {
    const { type, children, className, onClick, onSubmit, ...rest } = props;
     const classes: string[] = className ? className.split(' ') : [''];
     const classNames: string = ['c-btn'].concat(classes).join(' ');

     return (
         <button className={classNames} type={type} onClick={onClick} {...rest}>
             {children}
         </button>
     );
 };
 ```

<img src="https://user-images.githubusercontent.com/7137767/105580836-d46c9080-5d9f-11eb-89cc-86bfe7d0a3f2.png" width="400" />

